### PR TITLE
[FEAT] freegrow-git worktree 커맨드 및 릴리스 워크플로우 개선

### DIFF
--- a/plugins/freegrow-git/README.md
+++ b/plugins/freegrow-git/README.md
@@ -13,10 +13,13 @@ Freegrow 팀 전용 Git 워크플로우 자동화 플러그인입니다. 커밋,
 | 커맨드 | 설명 |
 |--------|------|
 | `/freegrow-git:start` | 이슈 생성 + 브랜치 생성 (통합) |
+| `/freegrow-git:worktree` | 이슈 생성 + 워크트리(격리 디렉토리) 생성 |
 | `/freegrow-git:com` | Freegrow 형식 커밋 |
 | `/freegrow-git:pr` | PR 생성 + Development Log 자동 정리 |
 
 ## 워크플로우
+
+### 일반 작업 (`/start`)
 
 ```
 1. /start "[FEAT] 기능명"
@@ -32,6 +35,22 @@ Freegrow 팀 전용 Git 워크플로우 자동화 플러그인입니다. 커밋,
 4. /pr
       ↓
    PR 생성 (Development Log 자동 정리)
+```
+
+### 병렬 작업 (`/worktree`)
+
+```
+1. /worktree "[FEAT] 기능명"
+      ↓
+   이슈 #3 생성 + .claude/worktrees/3-기능명 워크트리 생성
+      ↓
+2. cd .claude/worktrees/3-기능명 에서 코드 작업
+      ↓
+3. /com
+      ↓
+   feat: 기능 구현 (#3) 커밋
+      ↓
+4. /pr → git worktree remove 로 정리
 ```
 
 ---
@@ -76,7 +95,46 @@ URL: https://github.com/owner/repo/issues/3
 
 ---
 
-### 2. `/com` - 커밋
+### 2. `/worktree` - 워크트리 작업 시작
+
+이슈를 생성하고 **격리된 워크트리 디렉토리**에서 작업을 시작합니다. 기존 브랜치 작업을 중단하지 않고 새 작업을 병렬로 진행할 때 사용합니다.
+
+**사용법:**
+```bash
+/freegrow-git:wt 새 기능 병렬 개발
+/freegrow-git:wt 긴급 버그 수정          # → [FIX] 자동 판단
+/freegrow-git:wt [FEAT] 결제 모듈 추가   # → 타입 직접 지정
+```
+
+**결과:**
+```
+✅ 워크트리 작업 시작 완료!
+
+이슈: #3 [FEAT] 사용자 인증 기능
+URL: https://github.com/owner/repo/issues/3
+
+브랜치: feature/3-user-auth
+워크트리: .claude/worktrees/3-user-auth
+
+📁 이동 방법:
+  cd .claude/worktrees/3-user-auth
+
+🧹 작업 완료 후 정리:
+  git worktree remove .claude/worktrees/3-user-auth
+  git branch -d feature/3-user-auth
+```
+
+**start vs worktree:**
+
+| 항목 | `/start` | `/worktree` |
+|------|----------|-------|
+| 작업 위치 | 현재 repo (브랜치 전환) | 격리된 디렉토리 |
+| 병렬 작업 | 불가 | 가능 |
+| 정리 필요 | 없음 | `git worktree remove` 필요 |
+
+---
+
+### 3. `/com` - 커밋
 
 Freegrow 형식에 맞는 **상세한 커밋 메시지**를 자동 생성합니다.
 
@@ -137,7 +195,7 @@ feat: 바텀시트 실시간 UI 업데이트 구현 (#10)
 
 ---
 
-### 3. `/pr` - PR 생성
+### 4. `/pr` - PR 생성
 
 Freegrow 템플릿에 맞는 PR을 생성합니다. Development Log는 커밋 히스토리를 분석하여 자동 생성됩니다.
 

--- a/plugins/freegrow-git/commands/worktree.md
+++ b/plugins/freegrow-git/commands/worktree.md
@@ -1,0 +1,137 @@
+---
+description: 워크트리 기반 격리 작업 시작. 이슈 생성 + git worktree로 독립 디렉토리 생성.
+---
+
+# Freegrow 워크트리 작업 시작
+
+이슈를 생성하고, **격리된 워크트리 디렉토리**에서 작업을 시작합니다.
+기존 브랜치 작업을 유지하면서 병렬로 새 작업을 할 때 유용합니다.
+
+## 인자
+
+`$ARGUMENTS` - 작업 내용 (타입은 자동 판단)
+
+## 실행 절차
+
+### 1. 현재 상태 확인
+
+```bash
+git status
+git branch --show-current
+```
+
+> 현재 브랜치의 미커밋 변경사항이 있으면 경고를 출력합니다. (워크트리 생성은 계속 진행)
+
+### 2. 타입 자동 판단
+
+**사용자가 타입을 명시하지 않으면 내용에서 자동으로 판단합니다.**
+
+| 키워드 | 판단 타입 |
+|--------|----------|
+| `fix`, `bug`, `수정`, `버그`, `오류`, `에러` | `[FIX]` |
+| `docs`, `readme`, `문서`, `doc` | `[DOCS]` |
+| `refactor`, `리팩`, `개선`, `정리` | `[REFACTOR]` |
+| `chore`, `설정`, `빌드`, `config`, `ci`, `cd` | `[CHORE]` |
+| `test`, `테스트` | `[TEST]` |
+| 그 외 모든 경우 | `[FEAT]` (기본값) |
+
+### 3. 이슈 생성
+
+```bash
+gh issue create \
+  --title "[타입] 제목" \
+  --body "## 💡 Issue
+이슈 설명
+
+## 📝 todo
+- [ ] 작업 항목" \
+  --assignee @me
+```
+
+### 4. 이슈 번호 추출
+
+```bash
+gh issue list --limit 1 --json number --jq '.[0].number'
+```
+
+### 5. 브랜치 및 워크트리 이름 생성
+
+이슈 제목에서 브랜치 설명을 추출합니다:
+- `[FEAT] 사용자 인증 기능` → 브랜치: `feature/3-user-auth`, 워크트리 디렉토리: `.claude/worktrees/3-user-auth`
+
+규칙:
+- 소문자 변환
+- 공백 → 하이픈
+- 특수문자 제거
+- 영문 변환 권장
+
+### 6. 워크트리 디렉토리 생성
+
+`.claude/worktrees/` 디렉토리가 없으면 먼저 생성합니다:
+
+```bash
+mkdir -p .claude/worktrees
+```
+
+새 브랜치와 함께 워크트리를 생성합니다:
+
+```bash
+git worktree add .claude/worktrees/이슈번호-설명 -b feature/이슈번호-설명
+```
+
+### 7. .gitignore 확인
+
+`.claude/worktrees/`가 `.gitignore`에 등록되어 있는지 확인합니다.
+없으면 자동으로 추가합니다:
+
+```bash
+grep -q ".claude/worktrees" .gitignore || echo ".claude/worktrees/" >> .gitignore
+```
+
+### 8. 결과 출력
+
+```
+✅ 워크트리 작업 시작 완료!
+
+이슈: #3 [FEAT] 사용자 인증 기능
+URL: https://github.com/owner/repo/issues/3
+
+브랜치: feature/3-user-auth
+워크트리: .claude/worktrees/3-user-auth
+
+📁 워크트리 이동 방법:
+  cd .claude/worktrees/3-user-auth
+
+🧹 작업 완료 후 정리 방법:
+  git worktree remove .claude/worktrees/3-user-auth
+  git branch -d feature/3-user-auth
+
+다음 단계:
+1. 위 경로로 이동하여 코드 작업
+2. /com 으로 커밋 (워크트리 내에서)
+3. /pr 으로 PR 생성
+```
+
+## 사용 예시
+
+```
+/freegrow-git:wt 새 기능 병렬 개발       # → [FEAT] 새 기능 병렬 개발
+/freegrow-git:wt 긴급 버그 수정          # → [FIX] 긴급 버그 수정
+/freegrow-git:wt [FEAT] 결제 모듈 추가   # → [FEAT] 결제 모듈 추가
+```
+
+## start vs wt 비교
+
+| 항목 | `/start` | `/wt` |
+|------|----------|-------|
+| 작업 디렉토리 | 현재 repo (브랜치 전환) | 격리된 워크트리 디렉토리 |
+| 병렬 작업 | 불가 (브랜치 전환 필요) | 가능 (각 워크트리 독립) |
+| 사용 시점 | 일반적인 단일 작업 | 여러 이슈 동시 작업 |
+| 정리 필요 | 없음 | `git worktree remove` 필요 |
+
+## 주의사항
+
+- develop 브랜치 기준으로 워크트리가 생성됩니다
+- `.claude/worktrees/` 경로는 `.gitignore`에 자동 추가됩니다
+- 워크트리 작업 완료 후 반드시 `git worktree remove`로 정리하세요
+- Assignee 자동 설정: 현재 로그인된 사용자 (`@me`)


### PR DESCRIPTION
## 📋 Summary

freegrow-git 플러그인에 워크트리 기반 병렬 작업 커맨드(`/worktree`)를 추가하고, GitHub Actions 자동 릴리스 워크플로우를 개선했습니다.

---

## ✨ 구현된 기능

### 1. `/freegrow-git:worktree` 커맨드 추가
- 이슈 생성 + `git worktree add`로 격리된 디렉토리 생성
- 기존 브랜치 작업을 유지하면서 새 작업을 병렬로 진행 가능
- `.claude/worktrees/이슈번호-설명` 경로에 워크트리 자동 생성
- `.gitignore`에 `.claude/worktrees/` 자동 등록
- 작업 완료 후 cleanup 명령어 안내 포함

### 2. README 업데이트
- 커맨드 요약 표에 `/worktree` 추가
- 일반 작업(`/start`) vs 병렬 작업(`/worktree`) 워크플로우 비교 섹션 추가
- `start` vs `worktree` 비교표 추가 (작업 위치, 병렬 가능 여부, 정리 필요 여부)

### 3. GitHub Actions 자동 릴리스 개선
- 릴리스 태그에 타임스탬프 추가로 동일 버전 재릴리스 가능

---

## 📝 Development Log

### 주요 변경 사항
- `feat`: freegrow-git 플러그인에 worktree 커맨드 추가 (`d17a7bb`)
- `feat`: 릴리스 태그에 타임스탬프 추가 (`6e093f0`)

### 변경된 파일
- `plugins/freegrow-git/commands/worktree.md` - worktree 커맨드 신규 추가 (137줄)
- `plugins/freegrow-git/README.md` - 커맨드 문서 업데이트
- `.github/workflows/auto-release.yml` - 타임스탬프 태그 방식으로 변경

### 작업 요약
병렬 작업 시나리오를 지원하기 위해 `/worktree` 커맨드를 추가했습니다. 기존 `/start` 커맨드가 브랜치 전환 방식이라면, `/worktree`는 격리된 디렉토리에서 독립적으로 작업할 수 있어 여러 이슈를 동시에 진행할 때 유용합니다.