### PR TITLE
[CHORE] freegrow-git worktree 커맨드 마켓플레이스 반영 및 버전 1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Freegrow 내부 개발자용 Claude Code 플러그인 마켓플레이스",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {


### PR DESCRIPTION
## 📋 Summary

PR #6 머지 이후 누락된 마켓플레이스 업데이트를 반영합니다. freegrow-git 플러그인에 추가된 \`/worktree\` 커맨드를 \`marketplace.json\`에 명시하고, 버전을 \`1.2.0\`으로 업데이트했습니다.

---

## ✨ 구현된 기능

### 1. marketplace.json worktree 커맨드 반영
- \`freegrow-git\` 플러그인 항목에 \`./commands/worktree.md\` 추가
- 마켓플레이스 업데이트 시 worktree 커맨드가 정상 배포됨

### 2. 마켓플레이스 버전 업
- \`metadata.version\`: \`1.1.0\` → \`1.2.0\`
- main 머지 시 GitHub Actions가 \`v1.2.0.타임스탬프\`로 자동 릴리스

---

## 📝 Development Log

### 주요 변경 사항
- \`chore\`: marketplace.json에 freegrow-git worktree 커맨드 추가 및 버전 업 (`c1dc728`)
- \`chore\`: 마켓플레이스 버전 1.1.0 → 1.2.0 업데이트 (`a780051`)

### 변경된 파일
- \`.claude-plugin/marketplace.json\` - worktree 커맨드 추가, 버전 1.2.0 반영

### 작업 요약
\`marketplace.json\`은 커맨드를 명시적으로 나열하는 방식이기 때문에, \`commands/worktree.md\` 추가 시 수동으로 항목을 추가해야 합니다. 이번 PR에서 해당 누락을 보완하고 버전을 올려 정식 릴리스 준비를 완료합니다.