### PR TITLE
[CHORE] freegrow-git start 커맨드에 RELEASE 타입 및 Git Flow 브랜치 전략 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Freegrow 내부 개발자용 Claude Code 플러그인 마켓플레이스",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
@@ -230,7 +230,7 @@
       "name": "freegrow-git",
       "source": "./plugins/freegrow-git",
       "description": "Freegrow 팀 전용 Git 워크플로우 자동화 - 커밋, 브랜치, 이슈, PR 형식 통일",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "PROPRIETARY",
       "keywords": ["git", "workflow", "commit", "pr", "freegrow"],
       "commands": [

--- a/plugins/freegrow-git/commands/start.md
+++ b/plugins/freegrow-git/commands/start.md
@@ -26,6 +26,7 @@ git pull origin develop
 **자동 판단 규칙:**
 | 키워드 | 판단 타입 |
 |--------|----------|
+| `release`, `릴리즈`, `릴리스`, `배포`, `버전` | `[RELEASE]` |
 | `fix`, `bug`, `수정`, `버그`, `오류`, `에러` | `[FIX]` |
 | `docs`, `readme`, `문서`, `doc` | `[DOCS]` |
 | `refactor`, `리팩`, `개선`, `정리` | `[REFACTOR]` |
@@ -62,8 +63,27 @@ gh issue list --limit 1 --json number --jq '.[0].number'
 
 ### 5. 브랜치 이름 생성
 
-이슈 제목에서 브랜치 설명을 추출합니다:
+이슈 제목에서 브랜치 설명을 추출합니다. **Git Flow 전략에 따라 타입별로 브랜치 prefix가 결정됩니다:**
+
+#### Git Flow 브랜치 전략
+
+```
+main ──────────────────────────────────────── (프로덕션 릴리즈)
+  │
+develop ────────────────────────────────────── (통합 개발)
+  │              │
+feature/*    release/*    hotfix/*
+(기능 개발)  (릴리즈 준비)  (긴급 수정)
+```
+
+| 타입 | 브랜치 prefix | 설명 |
+|------|-------------|------|
+| `[RELEASE]` | `release/` | 릴리즈 준비 브랜치 (develop → main) |
+| 그 외 모든 타입 | `feature/` | 기능/수정 브랜치 (develop → develop) |
+
+예시:
 - `[FEAT] 사용자 인증 기능` → `feature/3-user-auth`
+- `[RELEASE] v1.2.0` → `release/3-v1-2-0`
 
 규칙:
 - 소문자 변환
@@ -74,6 +94,10 @@ gh issue list --limit 1 --json number --jq '.[0].number'
 ### 6. 브랜치 생성 및 체크아웃
 
 ```bash
+# [RELEASE] 타입인 경우
+git checkout -b release/이슈번호-설명
+
+# 그 외 타입인 경우
 git checkout -b feature/이슈번호-설명
 ```
 
@@ -101,6 +125,8 @@ URL: https://github.com/owner/repo/issues/3
 /freegrow-git:start 로그인 버그 수정          # → [FIX] 로그인 버그 수정 (버그 키워드)
 /freegrow-git:start README 문서 업데이트      # → [DOCS] README 문서 업데이트 (문서 키워드)
 /freegrow-git:start [FEAT] 사용자 인증        # → [FEAT] 사용자 인증 (명시적 타입)
+/freegrow-git:start v1.2.0 릴리즈             # → [RELEASE] v1.2.0 릴리즈 (릴리즈 키워드)
+/freegrow-git:start [RELEASE] v1.2.0          # → [RELEASE] v1.2.0 (명시적 타입)
 ```
 
 ## 자동 변환 규칙
@@ -111,9 +137,12 @@ URL: https://github.com/owner/repo/issues/3
 | `로그인 버그 수정` | `[FIX] 로그인 버그 수정` | `feature/3-login-bug-fix` |
 | `README 문서 업데이트` | `[DOCS] README 문서 업데이트` | `feature/3-readme-docs` |
 | `[FEAT] 사용자 인증` | `[FEAT] 사용자 인증` | `feature/3-user-auth` |
+| `v1.2.0 릴리즈` | `[RELEASE] v1.2.0 릴리즈` | `release/3-v1-2-0` |
+| `[RELEASE] v1.2.0` | `[RELEASE] v1.2.0` | `release/3-v1-2-0` |
 
 ## 주의사항
 
+- **Git Flow 전략 준수**: `feature/*` 브랜치는 `develop`에서 시작하고, `release/*` 브랜치는 릴리즈 준비 후 `main`으로 머지
 - develop 브랜치에서 시작
 - Assignee 자동 설정: 현재 로그인된 사용자 (`@me`)
 - 이슈 생성 실패 시 브랜치 생성 안함

--- a/plugins/freegrow-git/plugin.json
+++ b/plugins/freegrow-git/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "freegrow-git",
   "description": "Freegrow 팀 전용 Git 워크플로우 자동화 - 커밋, 브랜치, 이슈, PR 형식 통일",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "author": {
     "name": "Freegrow Enterprise"
   },


### PR DESCRIPTION
## 📋 Summary
Git Flow 브랜치 전략을 따르기 위해 \`/start\` 커맨드에 \`[RELEASE]\` 타입을 추가했습니다. 기존에는 릴리즈 작업 시 \`[CHORE]\` 타입과 \`feature/\` 브랜치가 생성되었으나, 이제 \`[RELEASE]\` 타입 감지 시 \`release/\` prefix 브랜치가 자동 생성됩니다.

## 📣 Related Issue
- close #8

---

## ✨ 구현된 기능

### 1. [RELEASE] 타입 자동 판단
- 키워드 감지: `release`, `릴리즈`, `릴리스`, `배포`, `버전`
- 명시적 사용: `[RELEASE]` 또는 `release` prefix

### 2. Git Flow 브랜치 전략 준수
- 기존: 모든 타입이 `feature/이슈번호-설명` 브랜치 생성
- 변경: `[RELEASE]` 타입은 `release/이슈번호-설명` 브랜치 생성
- 문서에 Git Flow 다이어그램 추가 (`main` / `develop` / `feature/*` / `release/*` / `hotfix/*`)

### 3. 버전 업데이트
- `plugin.json`: 1.0.0 → 1.2.0
- `marketplace.json`: freegrow-git 1.1.0 → 1.2.0, metadata 1.2.0 → 1.3.0

---

## 📝 Development Log

### 주요 변경 사항
- chore: freegrow-git start 커맨드에 RELEASE 타입 및 Git Flow 브랜치 전략 추가 (#8) (cdae9f7)

### 변경된 파일
- `plugins/freegrow-git/commands/start.md` - RELEASE 타입 판단 규칙, Git Flow 다이어그램, 브랜치 분기 로직, 사용 예시 추가
- `plugins/freegrow-git/plugin.json` - 버전 1.0.0 → 1.2.0
- `.claude-plugin/marketplace.json` - freegrow-git 버전 및 metadata 버전 업데이트

### 작업 요약
Git Flow 워크플로우를 올바르게 따르기 위한 `/start` 커맨드 개선. 릴리즈 작업 시 적절한 타입과 브랜치 prefix가 자동으로 설정됩니다.