### PR TITLE
[FEAT] 하네스 승격: plugin.json hooks 필드 금지 규칙

### DIFF
--- a/plugins/freegrow-harness/CLAUDE.md
+++ b/plugins/freegrow-harness/CLAUDE.md
@@ -16,6 +16,9 @@
 - 프로젝트 루트에 CLAUDE.md를 유지하여 프로젝트별 규칙을 명시해라.
 - README.md에 빌드 및 배포 방법을 반드시 포함해라.
 
+### 플러그인 개발
+- Claude Code plugin.json에 hooks 필드를 넣지 마라. hooks는 plugin.json에서 지원하지 않는 필드이며, hooks/ 디렉토리만 있으면 자동 인식된다.
+
 ## 개인 하네스 연동
 
 이 플러그인은 `~/.claude/harness/personal/` 디렉토리에서 개인 하네스를 자동 로드합니다.


### PR DESCRIPTION
## 📋 Summary
개인 하네스 common-001을 전사 공통 하네스로 승격합니다.

## 하네스 내용
Claude Code plugin.json에 hooks 필드를 넣지 마라. hooks는 plugin.json에서 지원하지 않는 필드이며, hooks/ 디렉토리만 있으면 자동 인식된다.

## 출처
- 원본 ID: common-001
- 감지 방식: manual
- 트리거 횟수: 0회
- 배경: v1.4.0 릴리즈 시 plugin.json에 hooks 필드를 넣어 설치 에러 발생. hotfix로 수정 후 재발 방지를 위해 공통 규칙으로 승격.